### PR TITLE
Added -lpthread to GTest target_link_libraries() to fix build error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ if(GTEST_FOUND)
   target_link_libraries(unit_tests PUBLIC
     ${GTEST_BOTH_LIBRARIES}
     example
+    -lpthread
   )
 
   target_include_directories(unit_tests PUBLIC


### PR DESCRIPTION
Fixed build error resulting from missing pthread library reference; error report forthcoming...